### PR TITLE
removed not needed includes

### DIFF
--- a/source/SVD.h
+++ b/source/SVD.h
@@ -1,6 +1,4 @@
 #include <cmath>
-#include <cuda.h>
-#include <cuda_runtime.h>
 #include <algorithm>
 #include <utility>
 #include <tuple>


### PR DESCRIPTION
compiling without CUDA causes error. Both includes are already behind a define a few lines later